### PR TITLE
Add support for UID types (0x08)

### DIFF
--- a/src/plist.rs
+++ b/src/plist.rs
@@ -28,6 +28,8 @@ pub enum Plist {
     Integer(i64),
     /// A string value
     String(String),
+    /// UID Value
+    Uid(i64),
 }
 
 pub type Array = Vec<Plist>;


### PR DESCRIPTION
UIDs are variable length numbers with a size of at least 1 byte.

This implements Uids via an i64, which means we cannot store Uids with
more than 8 bytes. The parser will panic if it encounters an Uid with
more than 8 bytes.

I'm aware this library is quite old, but its code quality is quite good. If you're not interested in maintaining this library anymore feel free to just close this Pull Request. I don't mind :-)